### PR TITLE
Add informed package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12417,6 +12417,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/informed": {
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/informed/-/informed-4.39.0.tgz",
+      "integrity": "sha512-AwXRDQppkvwiK/jalkRnEF0wWL9IdM5gDDUUMOXwWZ/7Z9tKCO1fDNMErJPZneWoPS2+mM7jODbirU0KSuGSYw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -30291,6 +30300,11 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
+    },
+    "informed": {
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/informed/-/informed-4.39.0.tgz",
+      "integrity": "sha512-AwXRDQppkvwiK/jalkRnEF0wWL9IdM5gDDUUMOXwWZ/7Z9tKCO1fDNMErJPZneWoPS2+mM7jODbirU0KSuGSYw=="
     },
     "inherits": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.1",
     "axios": "^1.2.2",
+    "informed": "^4.39.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",


### PR DESCRIPTION
I went to needlessly great lengths to factor this out as a single commit, because I'm overly particular about my merges. Plus everyone relies on the packages file, so why not get it updated promptly?